### PR TITLE
[Normative] Fix issue in locating correct pattern in GetNumberFormatP…

### DIFF
--- a/section11/numberformat_diff.html
+++ b/section11/numberformat_diff.html
@@ -658,8 +658,9 @@
             1. Else,
               1. Assert: _compactDisplay_ is `"long"`.
               1. Let _displayNotation_ be `"compactLong"`.
-        1. Let _patterns_ be _patterns_.[[&lt;_displayNotation_&gt;]].
         1. Let _signDisplay_ be _numberFormat_.[[SignDisplay]].
+        1. Let _patterns_ be _patterns_.[[&lt;_signDisplay_&gt;]].
+        1. Let _patterns_ be _patterns_.[[&lt;_displayNotation_&gt;]].
         1. If _signDisplay_ is `"never"`, then
           1. Let _pattern_ be _patterns_.[[zeroPattern]].
         1. Else if _signDisplay_ is `"auto"`, then


### PR DESCRIPTION
…attern

As per https://github.com/tc39/proposal-unified-intl-numberformat/issues/26, the pattern hierarchy is `patterns` -> `signDisplay` -> `displayNotation` -> `zero/negative/positionPattern`. Currently in the spec it’s reversed (`patterns` -> `displayNotation` -> `signDisplay`)

Reference implementation; https://github.com/formatjs/formatjs/blob/master/packages/intl-unified-numberformat/src/core.ts#L889